### PR TITLE
Fix typo and error message

### DIFF
--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -50,17 +50,15 @@ import { helper } from "./helper";
 
 class CLIEngine {
   /**
-   * @description cached debug logsd
+   * Cached debug logs
    */
   debugLogs: string[] = [];
 
   /**
-   * detect whether the process is a bundled electrop app
+   * Detect whether the process is a bundled electron app
    */
   isBundledElectronApp(): boolean {
-    return process.versions && process.versions.electron && !(process as any).defaultApp
-      ? true
-      : false;
+    return !!(process.versions?.electron && !(process as any).defaultApp);
   }
 
   /**

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -143,7 +143,7 @@ export class PackageService {
           }
         } while (true);
       } else {
-        throw new Error(`Unknown response code: ${uploadResponse.status}}`);
+        throw new Error(`Unknown response code: ${uploadResponse.status}`);
       }
     } catch (error: any) {
       // this.logger?.error("Sideloading failed.");


### PR DESCRIPTION
## Summary
- clean up comments and electron app check
- fix malformed error message in packageService

## Testing
- `pnpm -r --filter ./packages/cli --filter ./packages/fx-core test:unit` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.6.12.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68432304c430832f9ec411442882bf33