### PR TITLE
Fix event mapping bug

### DIFF
--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -87,7 +87,7 @@ export async function convertUIConfigToJson<T extends string | string[] | boolea
   }
   if ("onDidChangeSelection" in config && (config as MultiSelectConfig).onDidChangeSelection) {
     const funcId = setFunc((config as MultiSelectConfig).onDidChangeSelection!);
-    (newConfig as any).validation = <CustomizeFuncRequestType>{
+    (newConfig as any).onDidChangeSelection = <CustomizeFuncRequestType>{
       type: "OnSelectionChangeFunc",
       id: funcId,
     };


### PR DESCRIPTION
## Summary
- correct mapping of `onDidChangeSelection` handler in server utils

## Testing
- `pnpm -r test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684d41fbd5988325b9c043928fbf7be6