### PR TITLE
Fix package.json path for CLI telemetry initialization

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,9 @@ import { TelemetryProperty } from "./telemetry/cliTelemetryEvents";
 import { logger } from "./commonlib/logger";
 
 export function initTelemetryReporter(): void {
-  const cliPackage = JSON.parse(fs.readFileSync(path.join(__dirname, "/../package.json"), "utf8"));
+  const cliPackage = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8")
+  );
   const reporter = new CliTelemetryReporter(
     cliPackage.aiKey,
     constants.cliTelemetryPrefix,


### PR DESCRIPTION
## Summary
- fix incorrect path when reading CLI package.json

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684d41fbd5988325b9c043928fbf7be6