### PR TITLE
Fix remove return value in conversation storage

### DIFF
--- a/packages/sdk/src/conversation/storage.ts
+++ b/packages/sdk/src/conversation/storage.ts
@@ -45,14 +45,14 @@ export class DefaultConversationReferenceStore implements ConversationReferenceS
       return false;
     }
 
-    if (await this.storeFileExists()) {
-      const data = await this.readFromFile();
-      if (data[key] !== undefined) {
-        delete data[key];
-        await this.writeToFile(data);
-      }
+    const data = await this.readFromFile();
+    if (data[key] !== undefined) {
+      delete data[key];
+      await this.writeToFile(data);
+      return true;
     }
-    return true;
+
+    return false;
   }
 
   public async list(


### PR DESCRIPTION
## Summary
- fix `remove` return value in `DefaultConversationReferenceStore`

## Testing
- `pnpm -r test:unit` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684d41fbd5988325b9c043928fbf7be6