### PR TITLE
Fix env variable replacement

### DIFF
--- a/packages/fx-core/src/component/utils/common.ts
+++ b/packages/fx-core/src/component/utils/common.ts
@@ -138,14 +138,8 @@ export function expandEnvironmentVariable(
     for (const placeholder of placeholders) {
       const envName = placeholder.slice(3, -2).trim(); // removes `${{` and `}}`
       const envValue = envs ? envs[envName] : process.env[envName];
-      if (envName === "APP_NAME_SUFFIX") {
-        if (envValue !== undefined && envValue !== null) {
-          content = content.replace(placeholder, envValue);
-        }
-      } else {
-        if (envValue) {
-          content = content.replace(placeholder, envValue);
-        }
+      if (envValue !== undefined && envValue !== null) {
+        content = content.replace(placeholder, envValue);
       }
     }
   }

--- a/packages/fx-core/tests/component/utils.test.ts
+++ b/packages/fx-core/tests/component/utils.test.ts
@@ -171,6 +171,24 @@ describe("expandEnvironmentVariable", () => {
     const result = expandEnvironmentVariable(template, { APP_NAME_SUFFIX: "abc" });
     expect(result).to.equal("myappabc");
   });
+
+  it("should expand environment variable with empty string value", () => {
+    const template = "ENV_A value:${{ENV_A}}";
+    envRestore = mockedEnv({
+      ENV_A: "",
+    });
+    const result = expandEnvironmentVariable(template);
+    expect(result).to.equal("ENV_A value:");
+  });
+
+  it("should expand environment variable with zero value", () => {
+    const template = "ENV_A value:${{ENV_A}}";
+    envRestore = mockedEnv({
+      ENV_A: "0",
+    });
+    const result = expandEnvironmentVariable(template);
+    expect(result).to.equal("ENV_A value:0");
+  });
 });
 
 describe("TeamsFxTelemetryReporter", () => {


### PR DESCRIPTION
## Summary
- fix replace logic to honor empty env values in expandEnvironmentVariable
- add tests for empty and zero values

## Testing
- `npm run test:common` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d41fbd5988325b9c043928fbf7be6