### PR TITLE
Fix exitCode detection in preview task

### DIFF
--- a/packages/cli/src/cmds/preview/task.ts
+++ b/packages/cli/src/cmds/preview/task.ts
@@ -203,8 +203,9 @@ export class Task {
 
   public async terminate(): Promise<void> {
     return new Promise((resolve) => {
-      if (this.task?.exitCode) {
+      if (this.task?.exitCode !== undefined && this.task?.exitCode !== null) {
         resolve();
+        return;
       }
       const pid = this.task?.pid;
       if (pid === undefined) {


### PR DESCRIPTION
## Summary
- fix exitCode check before killing the preview task process

## Testing
- `npm run build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.6.12.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6412bf88325b80223880b9b22d4