### PR TITLE
Improve query parsing

### DIFF
--- a/packages/vscode-extension/src/commonlib/exchangeCode.ts
+++ b/packages/vscode-extension/src/commonlib/exchangeCode.ts
@@ -30,12 +30,11 @@ export async function getExchangeCode(): Promise<string> {
     });
 }
 
-/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */
-function parseQuery(uri: Uri): any {
-  return uri.query.split("&").reduce((prev: any, current) => {
-    const queryString: string[] = current.split("=");
-    prev[queryString[0]] = queryString[1];
-    return prev;
-  }, {});
+function parseQuery(uri: Uri): Record<string, string> {
+  const params = new URLSearchParams(uri.query);
+  const result: Record<string, string> = {};
+  for (const [key, value] of params.entries()) {
+    result[key] = value;
+  }
+  return result;
 }
-/* eslint-enable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */


### PR DESCRIPTION
## Summary
- replace manual URI query parsing with `URLSearchParams` in the vscode extension

## Testing
- `npm run test:unit` *(fails: Cannot find module 'path' or its corresponding type declarations)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6851b66e4448832590662510b3184bf3