### PR TITLE
Fix default export for extra-shot-mocha

### DIFF
--- a/packages/extra-shot-mocha/README.md
+++ b/packages/extra-shot-mocha/README.md
@@ -24,7 +24,7 @@ import it from "@microsoft/extra-shot-mocha";
 import { describe } from "mocha";
 import { expect } from "chai";
 
-describe("extra shot mocha it tests", async () => {
+describe("extra shot mocha it tests", () => {
   it("should run as normal mocha.it with sync arrow function", () => {
     expect(1).equals(1);
   });

--- a/packages/extra-shot-mocha/src/index.ts
+++ b/packages/extra-shot-mocha/src/index.ts
@@ -1,2 +1,5 @@
-export { it } from "./it";
+import { it } from "./it";
+
+export { it };
+export default it;
 export { describe, after, before, afterEach, beforeEach } from "mocha";

--- a/packages/extra-shot-mocha/tests/it.test.ts
+++ b/packages/extra-shot-mocha/tests/it.test.ts
@@ -5,7 +5,7 @@ import { describe } from "mocha";
 import { expect } from "chai";
 import { it } from "../src/it";
 
-describe("Advanced it tests", async () => {
+describe("Advanced it tests", () => {
   it("should run with only title");
 
   it("should run as normal mocha.it with sync function", function () {


### PR DESCRIPTION
## Summary
- export `it` as default in extra-shot-mocha
- update README example
- cleanup async `describe` in tests

## Testing
- `npm run test:unit` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6412bf88325b80223880b9b22d4