### PR TITLE
Fix Node <18 compatibility for MCP server

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,12 +34,14 @@
   "description": "MCP server for Microsoft 365 Agents Toolkit",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.9.0",
+    "node-fetch": "2.7.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/jest": "^29.5.13",
     "@types/node": "^20.10.0",
+    "@types/node-fetch": "^2.6.9",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",

--- a/packages/mcp-server/pnpm-lock.yaml
+++ b/packages/mcp-server/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@modelcontextprotocol/sdk':
     specifier: ^1.9.0
     version: 1.9.0
+  node-fetch:
+    specifier: 2.7.0
+    version: 2.7.0
   zod:
     specifier: ^3.24.2
     version: 3.24.2
@@ -22,6 +25,9 @@ devDependencies:
   '@types/node':
     specifier: ^20.10.0
     version: 20.10.0
+  '@types/node-fetch':
+    specifier: ^2.6.9
+    version: 2.6.9
   '@types/sinon':
     specifier: ^17.0.4
     version: 17.0.4
@@ -918,6 +924,13 @@ packages:
     resolution: {integrity: sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==}
     dependencies:
       undici-types: 5.26.5
+    dev: true
+
+  /@types/node-fetch@2.6.9:
+    resolution: {integrity: sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==}
+    dependencies:
+      '@types/node': 20.10.0
+      form-data: 4.0.2
     dev: true
 
   /@types/sinon@17.0.4:
@@ -4115,6 +4128,17 @@ packages:
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     dev: true
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}

--- a/packages/mcp-server/src/fetcher.ts
+++ b/packages/mcp-server/src/fetcher.ts
@@ -2,6 +2,15 @@
 // Licensed under the MIT license.
 import { z } from "zod";
 
+// Ensure global fetch is available on Node < 18
+if (typeof fetch === "undefined") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeFetch = require("node-fetch");
+  const fetchFn = (nodeFetch.default ?? nodeFetch) as typeof fetch;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  global.fetch = ((...args: any[]) => fetchFn(...args)) as any;
+}
+
 /**
  * Schema types supported by the fetcher
  */

--- a/packages/mcp-server/src/retriever.ts
+++ b/packages/mcp-server/src/retriever.ts
@@ -3,6 +3,15 @@
 
 import { z } from "zod";
 
+// Ensure global fetch is available on Node < 18
+if (typeof fetch === "undefined") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeFetch = require("node-fetch");
+  const fetchFn = (nodeFetch.default ?? nodeFetch) as typeof fetch;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  global.fetch = ((...args: any[]) => fetchFn(...args)) as any;
+}
+
 export const ResourceTypeEnum = z.enum(["documents", "samples", "issues", "code"]);
 export type ResourceType = z.infer<typeof ResourceTypeEnum>;
 


### PR DESCRIPTION
## Summary
- ensure `fetch` polyfill for MCP server
- add `node-fetch` dependency for server package

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6412bf88325b80223880b9b22d4