### PR TITLE
Fix deprecated Buffer usage in tests

### DIFF
--- a/packages/fx-core/tests/component/driver/devChannel/installApp.test.ts
+++ b/packages/fx-core/tests/component/driver/devChannel/installApp.test.ts
@@ -40,8 +40,8 @@ describe("InstallAppToChannelDriver", () => {
   manifest.id = "fake-id";
   const zip = new AdmZip();
   zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
-  zip.addFile("color.png", new Buffer(""));
-  zip.addFile("outlie.png", new Buffer(""));
+  zip.addFile("color.png", Buffer.from(""));
+  zip.addFile("outline.png", Buffer.from(""));
 
   const archivedFile = zip.toBuffer();
 

--- a/packages/fx-core/tests/component/driver/teamsApp/configure.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/configure.test.ts
@@ -57,8 +57,8 @@ describe("teamsApp/update", async () => {
     sinon.stub(fs, "pathExists").resolves(true);
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -95,8 +95,8 @@ describe("teamsApp/update", async () => {
       const zip = new AdmZip();
       const manifest = new TeamsAppManifest();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -136,8 +136,8 @@ describe("teamsApp/update", async () => {
         },
       ];
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -175,8 +175,8 @@ describe("teamsApp/update", async () => {
         },
       ];
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -200,8 +200,8 @@ describe("teamsApp/update", async () => {
       const manifest = new TeamsAppManifest();
       manifest.id = uuid();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest)));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;

--- a/packages/fx-core/tests/component/driver/teamsApp/create.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/create.test.ts
@@ -68,8 +68,8 @@ describe("teamsApp/create", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;

--- a/packages/fx-core/tests/component/driver/teamsApp/publishAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/publishAppPackage.test.ts
@@ -71,8 +71,8 @@ describe("teamsApp/publishAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -94,8 +94,8 @@ describe("teamsApp/publishAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -121,8 +121,8 @@ describe("teamsApp/publishAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;

--- a/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
@@ -813,8 +813,8 @@ describe("teamsApp/validateAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -868,8 +868,8 @@ describe("teamsApp/validateAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -915,8 +915,8 @@ describe("teamsApp/validateAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -1020,8 +1020,8 @@ describe("teamsApp/validateAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -1075,8 +1075,8 @@ describe("teamsApp/validateAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -1138,8 +1138,8 @@ describe("teamsApp/validateAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;
@@ -1188,8 +1188,8 @@ describe("teamsApp/validateAppPackage", async () => {
     sinon.stub(fs, "readFile").callsFake(async () => {
       const zip = new AdmZip();
       zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(new TeamsAppManifest())));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outlie.png", new Buffer(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
 
       const archivedFile = zip.toBuffer();
       return archivedFile;

--- a/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
@@ -61,7 +61,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     sinon.stub(fs, "stat").resolves();
     sinon.stub(cpUtils, "executeCommand").resolves("succeed");
     const manifestId = uuid.v4();
-    sinon.stub(fs, "readFile").resolves(new Buffer(`{"id": "${manifestId}"}`));
+    sinon.stub(fs, "readFile").resolves(Buffer.from(`{"id": "${manifestId}"}`));
     sinon.stub(fs, "writeFile").resolves();
     sinon.stub(fs, "rename").resolves();
     sinon.stub(fs, "copyFile").resolves();
@@ -417,7 +417,7 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     sinon.stub(fs, "stat").resolves();
     sinon.stub(cpUtils, "executeCommand").resolves("succeed");
     const manifestId = uuid.v4();
-    sinon.stub(fs, "readFile").resolves(new Buffer(`{"id": "${manifestId}"}`));
+    sinon.stub(fs, "readFile").resolves(Buffer.from(`{"id": "${manifestId}"}`));
     sinon.stub(fs, "writeFile").resolves();
     sinon.stub(fs, "rename").resolves();
     sinon.stub(fs, "copyFile").resolves();

--- a/packages/fx-core/tests/component/generator/spfxGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/spfxGenerator.test.ts
@@ -48,7 +48,7 @@ describe("SPFxGenerator", function () {
     sinon
       .stub(fs, "readFile")
       .resolves(
-        new Buffer(
+        Buffer.from(
           `{"id": "${manifestId}", "preconfiguredEntries": [{"title": {"default": "helloworld"}}]}`
         )
       );

--- a/packages/fx-core/tests/component/resource/appManifest/appstudio.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/appstudio.test.ts
@@ -131,10 +131,10 @@ describe.skip("appStudio", () => {
     it("get package successfully", async () => {
       m365TokenProvider.getAccessToken = sandbox.stub().returns(ok("token"));
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(""));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outline.png", new Buffer(""));
-      zip.addFile("zh-cn.json", new Buffer(""));
+      zip.addFile("manifest.json", Buffer.from(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
+      zip.addFile("zh-cn.json", Buffer.from(""));
       const archivedFile = zip.toBuffer();
       sandbox.stub(RetryHandler, "Retry").resolves({
         data: archivedFile,
@@ -155,10 +155,10 @@ describe.skip("appStudio", () => {
     it("get package successfully with unsupported file", async () => {
       m365TokenProvider.getAccessToken = sandbox.stub().returns(ok("token"));
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(""));
-      zip.addFile("color.png", new Buffer(""));
-      zip.addFile("outline.png", new Buffer(""));
-      zip.addFile("idk.json", new Buffer(""));
+      zip.addFile("manifest.json", Buffer.from(""));
+      zip.addFile("color.png", Buffer.from(""));
+      zip.addFile("outline.png", Buffer.from(""));
+      zip.addFile("idk.json", Buffer.from(""));
       const archivedFile = zip.toBuffer();
       sandbox.stub(RetryHandler, "Retry").resolves({
         data: archivedFile,
@@ -216,7 +216,7 @@ describe.skip("appStudio", () => {
     it("not valid json", async () => {
       const ctx = createContext();
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(""));
+      zip.addFile("manifest.json", Buffer.from(""));
       const info = zip.toBuffer();
 
       const inputs: InputsWithProjectPath = {
@@ -255,7 +255,7 @@ describe.skip("appStudio", () => {
         $schema: "schema",
       };
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+      zip.addFile("manifest.json", Buffer.from(JSON.stringify(json)));
       const info = zip.toBuffer();
 
       const inputs: InputsWithProjectPath = {
@@ -277,7 +277,7 @@ describe.skip("appStudio", () => {
         id: "fe58d257",
       };
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+      zip.addFile("manifest.json", Buffer.from(JSON.stringify(json)));
       const info = zip.toBuffer();
 
       const inputs: InputsWithProjectPath = {
@@ -300,7 +300,7 @@ describe.skip("appStudio", () => {
         id: "fe58d257-4ce6-427e-a388-496c89633774",
       };
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+      zip.addFile("manifest.json", Buffer.from(JSON.stringify(json)));
       const info = zip.toBuffer();
 
       const inputs: InputsWithProjectPath = {
@@ -324,7 +324,7 @@ describe.skip("appStudio", () => {
         id: "fe58d257-4ce6-427e-a388-496c89633774",
       };
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+      zip.addFile("manifest.json", Buffer.from(JSON.stringify(json)));
       const info = zip.toBuffer();
 
       const inputs: InputsWithProjectPath = {
@@ -351,7 +351,7 @@ describe.skip("appStudio", () => {
         id: "fe58d257-4ce6-427e-a388-496c89633774",
       };
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+      zip.addFile("manifest.json", Buffer.from(JSON.stringify(json)));
       const info = zip.toBuffer();
       sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
 
@@ -386,7 +386,7 @@ describe.skip("appStudio", () => {
         id: "fe58d257-4ce6-427e-a388-496c89633774",
       };
       const zip = new AdmZip();
-      zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+      zip.addFile("manifest.json", Buffer.from(JSON.stringify(json)));
       const info = zip.toBuffer();
       sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
 
@@ -469,7 +469,7 @@ describe("App-manifest Component - v3", () => {
     sandbox.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
     sandbox.stub(fs, "pathExists").resolves(true);
     sandbox.stub(fs, "readJSON").resolves(updatedManifest);
-    sandbox.stub(fs, "readFile").resolves(new Buffer(JSON.stringify(manifest)));
+    sandbox.stub(fs, "readFile").resolves(Buffer.from(JSON.stringify(manifest)));
     sandbox.stub(context.userInteraction, "showMessage").resolves(ok("Preview only"));
     sandbox.stub(ConfigureTeamsAppDriver.prototype, "execute").resolves(mockDriverRes);
     sandbox.stub(CreateAppPackageDriver.prototype, "execute").resolves(mockDriverRes);
@@ -486,7 +486,7 @@ describe("App-manifest Component - v3", () => {
     sandbox.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
     sandbox.stub(fs, "pathExists").resolves(true);
     sandbox.stub(fs, "readJSON").resolves(manifest);
-    sandbox.stub(fs, "readFile").resolves(new Buffer(JSON.stringify(manifest)));
+    sandbox.stub(fs, "readFile").resolves(Buffer.from(JSON.stringify(manifest)));
     sandbox.stub(context.userInteraction, "showMessage").resolves(ok("View in Developer Portal"));
     sandbox.stub(ConfigureTeamsAppDriver.prototype, "execute").resolves();
 
@@ -504,7 +504,7 @@ describe("App-manifest Component - v3", () => {
     sandbox.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
     sandbox.stub(fs, "pathExists").resolves(false);
     sandbox.stub(fs, "readJSON").resolves(updatedManifest);
-    sandbox.stub(fs, "readFile").resolves(new Buffer(JSON.stringify(manifest)));
+    sandbox.stub(fs, "readFile").resolves(Buffer.from(JSON.stringify(manifest)));
     sandbox.stub(context.userInteraction, "showMessage").resolves(ok("Preview and update"));
     sandbox.stub(ConfigureTeamsAppDriver.prototype, "execute").resolves(mockDriverRes);
     sandbox.stub(CreateAppPackageDriver.prototype, "execute").resolves(mockDriverRes);


### PR DESCRIPTION
## Summary
- replace deprecated `new Buffer()` with `Buffer.from()` in test suites
- correct icon filename typo in tests

## Testing
- `pnpm -r test:unit` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6412bf88325b80223880b9b22d4