### PR TITLE
Improve object cloning

### DIFF
--- a/packages/sdk/src/conversation/utils.ts
+++ b/packages/sdk/src/conversation/utils.ts
@@ -4,6 +4,7 @@
 import { TurnContext } from "@microsoft/agents-hosting";
 import { ConversationReference } from "@microsoft/agents-activity";
 import { NotificationTargetType } from "./interface";
+import { deepClone } from "../util/utils";
 
 /**
  * @internal
@@ -11,7 +12,7 @@ import { NotificationTargetType } from "./interface";
 export function cloneConversation(
   conversation: Partial<ConversationReference>
 ): ConversationReference {
-  return JSON.parse(JSON.stringify(conversation));
+  return deepClone(conversation);
 }
 
 /**

--- a/packages/sdk/src/util/utils.ts
+++ b/packages/sdk/src/util/utils.ts
@@ -232,3 +232,18 @@ export interface ClientCertificate {
   thumbprintSha256: string;
   privateKey: string;
 }
+
+/**
+ * Deep clone helper to copy complex objects.
+ * It uses the built-in structuredClone when available
+ * and falls back to JSON serialization otherwise.
+ *
+ * @internal
+ */
+export function deepClone<T>(obj: T): T {
+  const globalAny: any = globalThis as any;
+  if (typeof globalAny.structuredClone === "function") {
+    return globalAny.structuredClone(obj);
+  }
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/packages/spec-parser/src/specOptimizer.ts
+++ b/packages/spec-parser/src/specOptimizer.ts
@@ -3,6 +3,7 @@
 "use strict";
 
 import { OpenAPIV3 } from "openapi-types";
+import { deepClone } from "./utils";
 
 export interface OptimizerOptions {
   removeUnusedComponents: boolean;
@@ -25,7 +26,7 @@ export class SpecOptimizer {
       ...(options ?? {}),
     } as Required<OptimizerOptions>;
 
-    const newSpec = JSON.parse(JSON.stringify(spec));
+    const newSpec = deepClone(spec);
 
     if (mergedOptions.removeUserDefinedRootProperty) {
       SpecOptimizer.removeUserDefinedRootProperty(newSpec);

--- a/packages/spec-parser/src/specParser.browser.ts
+++ b/packages/spec-parser/src/specParser.browser.ts
@@ -18,7 +18,7 @@ import {
   WarningResult,
 } from "./interfaces";
 import { SpecParserError } from "./specParserError";
-import { Utils } from "./utils";
+import { Utils, deepClone } from "./utils";
 import { ConstantString } from "./constants";
 import { ValidatorFactory } from "./validators/validatorFactory";
 import { Validator } from "./validators/validator";
@@ -242,7 +242,7 @@ export class SpecParser {
         this.isSwaggerFile = true;
       }
 
-      const clonedUnResolveSpec = JSON.parse(JSON.stringify(this.unResolveSpec));
+      const clonedUnResolveSpec = deepClone(this.unResolveSpec);
       this.spec = (await this.parser.dereference(clonedUnResolveSpec)) as OpenAPIV3.Document;
     }
   }

--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -27,7 +27,7 @@ import {
 import { ConstantString } from "./constants";
 import { SpecParserError } from "./specParserError";
 import { SpecFilter } from "./specFilter";
-import { Utils } from "./utils";
+import { Utils, deepClone } from "./utils";
 import { ManifestUpdater } from "./manifestUpdater";
 import { AdaptiveCardGenerator } from "./adaptiveCardGenerator";
 import { wrapAdaptiveCard, wrapResponseSemantics } from "./adaptiveCardWrapper";
@@ -324,7 +324,7 @@ export class SpecParser {
         throw new SpecParserError(ConstantString.CancelledMessage, ErrorType.Cancelled);
       }
 
-      const clonedUnResolveSpec = JSON.parse(JSON.stringify(newUnResolvedSpec));
+      const clonedUnResolveSpec = deepClone(newUnResolvedSpec);
       const newSpec = await this.deReferenceSpec(clonedUnResolveSpec);
       return [newUnResolvedSpec, newSpec];
     } catch (err) {
@@ -662,7 +662,7 @@ export class SpecParser {
         this.isSwaggerFile = true;
       }
 
-      const clonedUnResolveSpec = JSON.parse(JSON.stringify(this.unResolveSpec));
+      const clonedUnResolveSpec = deepClone(this.unResolveSpec);
 
       this.spec = await this.deReferenceSpec(clonedUnResolveSpec);
     }

--- a/packages/spec-parser/src/utils.ts
+++ b/packages/spec-parser/src/utils.ts
@@ -549,3 +549,11 @@ export class Utils {
     }
   }
 }
+
+export function deepClone<T>(obj: T): T {
+  const globalAny: any = globalThis as any;
+  if (typeof globalAny.structuredClone === "function") {
+    return globalAny.structuredClone(obj);
+  }
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/packages/spec-parser/test/specParser.test.ts
+++ b/packages/spec-parser/test/specParser.test.ts
@@ -21,7 +21,7 @@ import { OpenAPI, OpenAPIV3 } from "openapi-types";
 import { SpecFilter } from "../src/specFilter";
 import { ManifestUpdater } from "../src/manifestUpdater";
 import { AdaptiveCardGenerator } from "../src/adaptiveCardGenerator";
-import { Utils } from "../src/utils";
+import { Utils, deepClone } from "../src/utils";
 import jsyaml from "js-yaml";
 import mockedEnv, { RestoreFn } from "mocked-env";
 import { SMEValidator } from "../src/validators/smeValidator";
@@ -2484,7 +2484,7 @@ describe("SpecParser", () => {
         },
       };
       const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
-      const cloneSpec = JSON.parse(JSON.stringify(spec));
+      const cloneSpec = deepClone(spec);
       cloneSpec.paths["/hello"].get.operationId = "getHello";
       const dereferenceStub = sinon
         .stub(specParser.parser, "dereference")


### PR DESCRIPTION
## Summary
- use structured clone fallback for deep copy
- refactor conversation helper to use new deepClone utility
- integrate deepClone in spec-parser modules
- adjust tests

## Testing
- `npm run test:unit:node` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b66e4448832590662510b3184bf3