### PR TITLE
Optimize array handling

### DIFF
--- a/packages/fx-core/src/component/driver/apiKey/utility/utility.ts
+++ b/packages/fx-core/src/component/driver/apiKey/utility/utility.ts
@@ -53,9 +53,7 @@ export async function getDomain(
   context.addTelemetryProperties({ [telemetryKeys.isCustomAPIKey]: isCustomAPIKey });
 
   const servers = filteredOperations.map((value) => value.server);
-
-  const uniqueServerUrls = servers.filter((value, index, self) => self.indexOf(value) === index);
-
+  const uniqueServerUrls = Array.from(new Set(servers));
   return uniqueServerUrls;
 }
 

--- a/packages/fx-core/src/component/driver/oauth/utility/utility.ts
+++ b/packages/fx-core/src/component/driver/oauth/utility/utility.ts
@@ -83,13 +83,13 @@ async function getandValidateOauthInfoFromSpec(
     throw new OauthAuthMissingInSpec(actionName, args.name);
   }
 
-  const domains = operations
-    .map((value) => {
-      return value.server;
-    })
-    .filter((value, index, self) => {
-      return self.indexOf(value) === index;
-    });
+  const domains = Array.from(
+    new Set(
+      operations.map((value) => {
+        return value.server;
+      })
+    )
+  );
   validateDomain(domains, actionName);
 
   // Need to separate the logic for different flows

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -300,21 +300,20 @@ export async function runWithLimitedConcurrency<T>(
   callback: (arg: T) => any,
   concurrencyLimit: number
 ): Promise<void> {
-  const queue: any[] = [];
+  const queue: Set<Promise<any>> = new Set();
   for (const item of items) {
     // fire the async function, add its promise to the queue, and remove
     // it from queue when complete
     const p = callback(item)
-      .then((res: any) => {
-        queue.splice(queue.indexOf(p), 1);
-        return res;
+      .finally(() => {
+        queue.delete(p);
       })
       .catch((err: any) => {
         throw err;
       });
-    queue.push(p);
+    queue.add(p);
     // if max concurrent, wait for one to finish
-    if (queue.length >= concurrencyLimit) {
+    if (queue.size >= concurrencyLimit) {
       await Promise.race(queue);
     }
   }

--- a/packages/fx-core/src/component/utils/ResourceGroupHelper.ts
+++ b/packages/fx-core/src/component/utils/ResourceGroupHelper.ts
@@ -101,11 +101,12 @@ export function selectResourceGroupLocationQuestion(
       if (getLocationsRes.isErr()) {
         throw getLocationsRes.error;
       }
+      const recommendedSet = new Set(recommendedLocations);
       const recommended = getLocationsRes.value.filter((location) => {
-        return recommendedLocations.indexOf(location) >= 0;
+        return recommendedSet.has(location);
       });
       const others = getLocationsRes.value.filter((location) => {
-        return recommendedLocations.indexOf(location) < 0;
+        return !recommendedSet.has(location);
       });
       return [
         ...recommended.map((location) => {

--- a/packages/fx-core/src/error/common.ts
+++ b/packages/fx-core/src/error/common.ts
@@ -37,11 +37,13 @@ export class MissingEnvironmentVariablesError extends UserError {
     const envFilePath = globalVars.envFilePath || "";
     const secretEnvFilePath = globalVars.envFilePath ? `${globalVars.envFilePath}.user` : "";
     const key = "error.common.MissingEnvironmentVariablesError";
-    const deduplicatedVaribleNames = variableNames
-      .split(",")
-      .map((name) => name.trim())
-      .filter((name, index, self) => self.indexOf(name) === index)
-      .join(", ");
+    const deduplicatedVaribleNames = Array.from(
+      new Set(
+        variableNames
+          .split(",")
+          .map((name) => name.trim())
+      )
+    ).join(", ");
     const errorOptions: UserErrorOptions = {
       source: camelCase(source),
       name: "MissingEnvironmentVariablesError",


### PR DESCRIPTION
## Summary
- optimize concurrency limiter to use `Set`
- dedupe arrays with `Set`
- use `Set` for quick recommended location lookup

## Testing
- `pnpm -r run lint` *(fails: unable to download pnpm)*
- `pnpm -r run build` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68545cb9b9488325a72a7f29d0868fcc