### PR TITLE
Fix command pattern matching

### DIFF
--- a/packages/sdk/src/conversation/sso/botSsoExecutionDialog.ts
+++ b/packages/sdk/src/conversation/sso/botSsoExecutionDialog.ts
@@ -299,12 +299,7 @@ export class BotSsoExecutionDialog extends ComponentDialog {
   private isPatternMatched(patterns: TriggerPatterns, text: string): boolean {
     const expressions = Array.isArray(patterns) ? patterns : [patterns];
 
-    for (const ex of expressions) {
-      const matches = this.matchPattern(ex, text);
-      return !!matches;
-    }
-
-    return false;
+    return expressions.some((ex) => !!this.matchPattern(ex, text));
   }
 
   private getMatchesCommandId(text: string): string | undefined {


### PR DESCRIPTION
## Summary
- fix pattern matching loop in BotSsoExecutionDialog to evaluate all patterns

## Testing
- `pnpm -r --filter ./packages/sdk run test --if-present` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68545cb9b9488325a72a7f29d0868fcc