### PR TITLE
Refactor API operation extraction

### DIFF
--- a/packages/fx-core/src/component/generator/openApiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/openApiSpec/helper.ts
@@ -1719,9 +1719,12 @@ export async function generateAdaptiveCardInPluginManifestForKiota(
   context: Context
 ): Promise<void> {
   try {
-    const operation = (await listAPIInfo(specPath)).APIs.filter((value) => value.isValid).map(
-      (value) => value.api
-    );
+    const operation = (await listAPIInfo(specPath)).APIs.reduce<string[]>((acc, value) => {
+      if (value.isValid) {
+        acc.push(value.api);
+      }
+      return acc;
+    }, []);
 
     const specParser = new SpecParser(specPath, getParserOptions(ProjectType.Copilot, true));
     await specParser.generateAdaptiveCardInPlugin(pluginManifestPath, operation, undefined);

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -2135,9 +2135,12 @@ export class FxCore {
         inputs[QuestionNames.ActionType] === ActionStartOptions.apiSpec().id &&
         !!inputs[QuestionNames.ActionManifestPath]
       ) {
-        inputs[QuestionNames.ApiOperation] = listResult.APIs.filter((value) => value.isValid).map(
-          (value) => value.api
-        );
+        inputs[QuestionNames.ApiOperation] = listResult.APIs.reduce<string[]>((acc, value) => {
+          if (value.isValid) {
+            acc.push(value.api);
+          }
+          return acc;
+        }, []);
       }
       authNameAndSchemes = this.parseAuthNameAndScheme(listResult, inputs);
 


### PR DESCRIPTION
## Summary
- refactor to use `reduce` instead of `filter` + `map` when listing valid API operations

## Testing
- `pnpm test` *(fails: Error when performing the request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68545cb9b9488325a72a7f29d0868fcc