### PR TITLE
Fix spawn error handling

### DIFF
--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -647,6 +647,10 @@ class CLIUserInteraction implements UserInteraction {
         timeout: args.timeout,
         env: args.env,
       });
+      childProcess.on("error", (error) => {
+        logger.error(`Execute task failed: ${error.message}`);
+        resolve(err(new ScriptExecutionError(error, args.cmd)));
+      });
       childProcess.on("close", (code: number) => {
         if (code === 0) {
           resolve(ok(""));


### PR DESCRIPTION
## Summary
- ensure runCommand resolves when spawn emits error

## Testing
- `npm --prefix packages/cli run test:unit` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545cb03f00832585af063feec4eec8