### PR TITLE
Fix mocha wrapper typing

### DIFF
--- a/packages/extra-shot-mocha/src/it.ts
+++ b/packages/extra-shot-mocha/src/it.ts
@@ -75,7 +75,7 @@ export function it(
     if (ctxOrFn instanceof Function) {
       t = mocha.it(title, ctxOrFn);
     } else {
-      t = mocha.it(title, async function (this) {
+      t = mocha.it(title, async function (this: mocha.Context) {
         addContext(this, JSON.stringify(ctxOrFn));
         await (fn as mocha.AsyncFunc).call(this);
       });


### PR DESCRIPTION
## Summary
- fix `async function (this)` syntax in `extra-shot-mocha` wrapper

## Testing
- `npx tsc -p packages/extra-shot-mocha/tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68565557887883259bc282fb402287ea