### PR TITLE
Improve helper efficiency

### DIFF
--- a/packages/fx-core/src/common/secretmasker/feature.ts
+++ b/packages/fx-core/src/common/secretmasker/feature.ts
@@ -309,8 +309,9 @@ function extractCharFeatures(token: string) {
 
 // Helper function to check if a token contains common secret-related keywords
 function containsSecretKeywords(token: string): number {
-  if (CredKeywordsEndsWith.some((keyword) => token.toLowerCase().endsWith(keyword))) return 1;
-  if (CredKeywordsEquals.some((keyword) => token.toLowerCase() === keyword)) return 1;
+  const lower = token.toLowerCase();
+  if (CredKeywordsEndsWith.some((keyword) => lower.endsWith(keyword))) return 1;
+  if (CredKeywordsEquals.some((keyword) => lower === keyword)) return 1;
   return 0;
 }
 

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -132,17 +132,12 @@ export class CollaborationUtil {
     dotEnvFilePath: string
   ): Promise<Result<{ [key: string]: string }, FxError>> {
     try {
-      const result: { [key: string]: string } = {};
       if (!(await fs.pathExists(dotEnvFilePath))) {
         throw new FileNotFoundError("CollaboratorUtil", dotEnvFilePath);
       }
 
       const envs = dotenv.parse(await fs.readFile(dotEnvFilePath));
-      const entries = Object.entries(envs);
-      for (const [key, value] of entries) {
-        result[key] = value;
-      }
-      return ok(result);
+      return ok(envs);
     } catch (error: any) {
       return err(
         new UserError(


### PR DESCRIPTION
## Summary
- streamline the secret keyword check by reusing the lowercase token
- simplify dotenv loading logic

## Testing
- `npx tsc -p packages/fx-core/tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx eslint packages/fx-core/src/common/secretmasker/feature.ts packages/fx-core/src/core/collaborator.ts` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6856555d2890832596005cd07f2a7d2d