### PR TITLE
Fix porter stemmer logic

### DIFF
--- a/packages/vscode-extension/src/officeChat/retrievalUtil/porter2Stemmer.ts
+++ b/packages/vscode-extension/src/officeChat/retrievalUtil/porter2Stemmer.ts
@@ -192,10 +192,7 @@ export function stemmer(value: string): string {
       if (value.endsWith("at") || value.endsWith("bl") || value.endsWith("iz")) {
         value += "e";
       } else if (doubleRegex.test(value)) {
-        const nonAeo = /[^aeo]/;
-        if (nonAeo.test(value.slice(0, -2))) {
-          value = value.slice(0, -1);
-        }
+        value = value.slice(0, -1);
       } else if (isShort(value)) {
         value += "e";
       }


### PR DESCRIPTION
## Summary
- improve logic when handling double consonants in the porter stemmer

## Testing
- `npx tsc packages/vscode-extension/src/officeChat/retrievalUtil/porter2Stemmer.ts --noEmit` *(fails: Property 'startsWith' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68565557887883259bc282fb402287ea