### PR TITLE
Fix template version filtering

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -80,11 +80,17 @@ export async function getTemplates(): Promise<Sample[]> {
   const version = getVersion();
   const availableSamples = (await sampleProvider.SampleCollection).samples.filter(
     (sample: SampleConfig) => {
-      if (sample.minimumCliVersion !== undefined) {
-        return semver.gte(version, sample.minimumCliVersion);
+      if (
+        sample.minimumCliVersion !== undefined &&
+        semver.lt(version, sample.minimumCliVersion)
+      ) {
+        return false;
       }
-      if (sample.maximumCliVersion !== undefined) {
-        return semver.lte(version, sample.maximumCliVersion);
+      if (
+        sample.maximumCliVersion !== undefined &&
+        semver.gt(version, sample.maximumCliVersion)
+      ) {
+        return false;
       }
       return true;
     }

--- a/packages/cli/tests/unit/utils.tests.ts
+++ b/packages/cli/tests/unit/utils.tests.ts
@@ -183,6 +183,65 @@ describe("Utils Tests", function () {
       const templates = await getTemplates();
       expect(templates.length).equals(1);
     });
+
+    it("filters samples have min and max cli version", async () => {
+      sandbox.stub(core.sampleProvider, "SampleCollection").value(
+        Promise.resolve({
+          filterOptions: {
+            capabilities: ["Tab"],
+            languages: ["TS"],
+            technologies: ["Azure"],
+          },
+          samples: [
+            {
+              id: "test1",
+              onboardDate: "2021-05-06",
+              title: "test1",
+              shortDescription: "test1",
+              fullDescription: "test1",
+              types: ["Tab"],
+              tags: [],
+              time: "1hr to run",
+              configuration: "",
+              thumbnailPath: "",
+              suggested: false,
+              minimumCliVersion: "1.0.0",
+              maximumCliVersion: "3.0.0",
+              downloadUrlInfo: {
+                owner: "",
+                repository: "",
+                ref: "",
+                dir: "",
+              },
+            },
+            {
+              id: "test2",
+              onboardDate: "2021-05-06",
+              title: "test2",
+              shortDescription: "test2",
+              fullDescription: "test2",
+              types: ["Tab"],
+              tags: [],
+              time: "1hr to run",
+              configuration: "",
+              thumbnailPath: "",
+              suggested: false,
+              minimumCliVersion: "1.0.0",
+              maximumCliVersion: "1.5.0",
+              downloadUrlInfo: {
+                owner: "",
+                repository: "",
+                ref: "",
+                dir: "",
+              },
+            },
+          ],
+        })
+      );
+      const templates = await getTemplates();
+      expect(templates.length).equals(1);
+      expect(templates[0].name).equals("test1");
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- handle both minimum and maximum CLI version constraints when filtering samples
- add regression test for min and max CLI version

## Testing
- `npm test --silent` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ae11dcfbc8325960370c44b46117c