### PR TITLE
Fix tenant switch token update

### DIFF
--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -182,6 +182,8 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   }
 
   async switchTenant(tenantId: string): Promise<Result<TokenCredential, FxError>> {
+    AzureAccountManager.tenantId = tenantId;
+    AzureAccountManager.teamsFxTokenCredential.setTenantId(tenantId);
     await saveTenantId(accountName, tenantId);
     return Promise.resolve(ok(AzureAccountManager.teamsFxTokenCredential));
   }

--- a/packages/cli/src/commonlib/azureLoginCI.ts
+++ b/packages/cli/src/commonlib/azureLoginCI.ts
@@ -126,6 +126,20 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   }
 
   switchTenant(tenantId: string): Promise<Result<TokenCredential, FxError>> {
+    AzureAccountManager.tenantId = tenantId;
+    if (fs.pathExistsSync(AzureAccountManager.secret)) {
+      AzureAccountManager.tokenCredential = new identity.ClientCertificateCredential(
+        tenantId,
+        AzureAccountManager.clientId,
+        AzureAccountManager.secret
+      );
+    } else {
+      AzureAccountManager.tokenCredential = new identity.ClientSecretCredential(
+        tenantId,
+        AzureAccountManager.clientId,
+        AzureAccountManager.secret
+      );
+    }
     return Promise.resolve(ok(AzureAccountManager.tokenCredential));
   }
 


### PR DESCRIPTION
## Summary
- update Azure CLI login tenant switch to set tenantId on credential
- same fix for CI login

## Testing
- `pnpm test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ae11dcfbc8325960370c44b46117c