### PR TITLE
Fix env placeholder removal in manifest updater

### DIFF
--- a/packages/spec-parser/src/manifestUpdater.ts
+++ b/packages/spec-parser/src/manifestUpdater.ts
@@ -527,12 +527,7 @@ export class ManifestUpdater {
 
   static removeEnvs(str: string): string {
     const placeHolderReg = /\${{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g;
-    const matches = placeHolderReg.exec(str);
-    let newStr = str;
-    if (matches != null) {
-      newStr = newStr.replace(matches[0], "");
-    }
-    return newStr;
+    return str.replace(placeHolderReg, "");
   }
 
   static removeAllSpecialCharacters(str: string): string {


### PR DESCRIPTION
## Summary
- fix removeEnvs to strip all placeholders

## Testing
- `pnpm -r run test:unit` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685ae11dcfbc8325960370c44b46117c